### PR TITLE
Features/F012

### DIFF
--- a/src/backend/FinanceManager.CatalogService/FinanceManager.CatalogService.Domain/Abstractions/IndentityModel.cs
+++ b/src/backend/FinanceManager.CatalogService/FinanceManager.CatalogService.Domain/Abstractions/IndentityModel.cs
@@ -1,8 +1,17 @@
 ﻿namespace FinanceManager.CatalogService.Domain.Abstractions;
 
+/// <summary>
+/// Базовый абстрактный класс для всех доменных сущностей с идентификацией
+/// </summary>
 public abstract class IdentityModel
 {
+    /// <summary>
+    /// Уникальный идентификатор сущности
+    /// </summary>
     public Guid Id { get; init; }
     
+    /// <summary>
+    /// Дата и время создания сущности
+    /// </summary>
     public DateTime CreatedAt { get; init; }
 }

--- a/src/backend/FinanceManager.CatalogService/FinanceManager.CatalogService.Domain/Abstractions/IndentityModel.cs
+++ b/src/backend/FinanceManager.CatalogService/FinanceManager.CatalogService.Domain/Abstractions/IndentityModel.cs
@@ -1,0 +1,8 @@
+﻿namespace FinanceManager.CatalogService.Domain.Abstractions;
+
+public abstract class IdentityModel
+{
+    public Guid Id { get; init; }
+    
+    public DateTime CreatedAt { get; init; }
+}

--- a/src/backend/FinanceManager.CatalogService/FinanceManager.CatalogService.Domain/Entities/Account.cs
+++ b/src/backend/FinanceManager.CatalogService/FinanceManager.CatalogService.Domain/Entities/Account.cs
@@ -1,0 +1,44 @@
+﻿using FinanceManager.CatalogService.Domain.Abstractions;
+
+namespace FinanceManager.CatalogService.Domain.Entities;
+
+public class Account(
+    Guid registryHolderId,
+    Guid accountTypeId,
+    Guid currencyId,
+    Guid bankId,
+    string name,
+    bool isIncludeInBalance,
+    bool isDefault,
+    bool isArchived = false,
+    bool isDeleted = false,
+    decimal? creditLimit = null) : IdentityModel
+{
+    public Guid RegistryHolderId { get; set; } = registryHolderId;
+    
+    public RegistryHolder RegistryHolder { get; set; } = null!;
+
+    public Guid AccountTypeId { get; set; } = accountTypeId;
+    
+    public AccountType AccountType { get; set; } = null!;
+
+    public Guid CurrencyId { get; set; } = currencyId;
+    
+    public Currency Currency { get; set; } = null!;
+
+    public Guid BankId { get; set; } = bankId;
+    
+    public Bank Bank { get; set; } = null!;
+
+    public string Name { get; set; } = name;
+
+    public bool IsIncludeInBalance { get; set; } = isIncludeInBalance;
+
+    public bool IsDefault { get; set; } = isDefault;
+
+    public bool IsArchived { get; set; } = isArchived;
+
+    public bool IsDeleted { get; set; } = isDeleted;
+
+    public decimal? CreditLimit { get; set; } = creditLimit;
+}

--- a/src/backend/FinanceManager.CatalogService/FinanceManager.CatalogService.Domain/Entities/Account.cs
+++ b/src/backend/FinanceManager.CatalogService/FinanceManager.CatalogService.Domain/Entities/Account.cs
@@ -2,6 +2,19 @@
 
 namespace FinanceManager.CatalogService.Domain.Entities;
 
+/// <summary>
+/// Банковский счет пользователя
+/// </summary>
+/// <param name="registryHolderId">Идентификатор владельца счета</param>
+/// <param name="accountTypeId">Идентификатор типа счета</param>
+/// <param name="currencyId">Идентификатор валюты</param>
+/// <param name="bankId">Идентификатор банка</param>
+/// <param name="name">Название счета</param>
+/// <param name="isIncludeInBalance">Включать ли счет в общий баланс</param>
+/// <param name="isDefault">Является ли счет по умолчанию</param>
+/// <param name="isArchived">Архивирован ли счет</param>
+/// <param name="isDeleted">Удален ли счет</param>
+/// <param name="creditLimit">Кредитный лимит счета</param>
 public class Account(
     Guid registryHolderId,
     Guid accountTypeId,
@@ -14,31 +27,74 @@ public class Account(
     bool isDeleted = false,
     decimal? creditLimit = null) : IdentityModel
 {
+    /// <summary>
+    /// Идентификатор владельца счета
+    /// </summary>
     public Guid RegistryHolderId { get; set; } = registryHolderId;
     
+    /// <summary>
+    /// Владелец счета
+    /// </summary>
     public RegistryHolder RegistryHolder { get; set; } = null!;
 
+    /// <summary>
+    /// Идентификатор типа счета
+    /// </summary>
     public Guid AccountTypeId { get; set; } = accountTypeId;
     
+    /// <summary>
+    /// Тип счета
+    /// </summary>
     public AccountType AccountType { get; set; } = null!;
 
+    /// <summary>
+    /// Идентификатор валюты счета
+    /// </summary>
+    
     public Guid CurrencyId { get; set; } = currencyId;
     
+    /// <summary>
+    /// Валюта счета
+    /// </summary>
     public Currency Currency { get; set; } = null!;
 
+    /// <summary>
+    /// Идентификатор банка
+    /// </summary>
     public Guid BankId { get; set; } = bankId;
     
+    /// <summary>
+    /// Банк, в котором открыт счет
+    /// </summary>
     public Bank Bank { get; set; } = null!;
 
+    /// <summary>
+    /// Название счета
+    /// </summary>
     public string Name { get; set; } = name;
 
+    /// <summary>
+    /// Флаг, указывающий, включать ли данный счет в расчет общего баланса
+    /// </summary>
     public bool IsIncludeInBalance { get; set; } = isIncludeInBalance;
 
+    /// <summary>
+    /// Флаг, указывающий, является ли счет счетом по умолчанию
+    /// </summary>
     public bool IsDefault { get; set; } = isDefault;
 
+    /// <summary>
+    /// Флаг архивирования счета
+    /// </summary>
     public bool IsArchived { get; set; } = isArchived;
 
+    /// <summary>
+    /// Флаг мягкого удаления счета
+    /// </summary>
     public bool IsDeleted { get; set; } = isDeleted;
 
+    /// <summary>
+    /// Кредитный лимит счета (если применимо)
+    /// </summary>
     public decimal? CreditLimit { get; set; } = creditLimit;
 }

--- a/src/backend/FinanceManager.CatalogService/FinanceManager.CatalogService.Domain/Entities/AccountType.cs
+++ b/src/backend/FinanceManager.CatalogService/FinanceManager.CatalogService.Domain/Entities/AccountType.cs
@@ -2,11 +2,26 @@
 
 namespace FinanceManager.CatalogService.Domain.Entities;
 
+/// <summary>
+/// Представляет тип финансового счета
+/// </summary>
+/// <param name="code">Код типа счета</param>
+/// <param name="description">Описание типа счета</param>
+/// <param name="isDeleted">Удален ли тип счета</param>
 public class AccountType(string code, string description, bool isDeleted = false) : IdentityModel
 {
+    /// <summary>
+    /// Уникальный код типа счета
+    /// </summary>
     public string Code { get; set; } =  code;
 
+    /// <summary>
+    /// Описание типа счета
+    /// </summary>
     public string Description { get; set; } = description;
 
+    /// <summary>
+    /// Флаг мягкого удаления типа счета
+    /// </summary>
     public bool IsDeleted { get; set; } = isDeleted;
 }

--- a/src/backend/FinanceManager.CatalogService/FinanceManager.CatalogService.Domain/Entities/AccountType.cs
+++ b/src/backend/FinanceManager.CatalogService/FinanceManager.CatalogService.Domain/Entities/AccountType.cs
@@ -1,0 +1,12 @@
+﻿using FinanceManager.CatalogService.Domain.Abstractions;
+
+namespace FinanceManager.CatalogService.Domain.Entities;
+
+public class AccountType(string code, string description, bool isDeleted = false) : IdentityModel
+{
+    public string Code { get; set; } =  code;
+
+    public string Description { get; set; } = description;
+
+    public bool IsDeleted { get; set; } = isDeleted;
+}

--- a/src/backend/FinanceManager.CatalogService/FinanceManager.CatalogService.Domain/Entities/Bank.cs
+++ b/src/backend/FinanceManager.CatalogService/FinanceManager.CatalogService.Domain/Entities/Bank.cs
@@ -2,11 +2,25 @@
 
 namespace FinanceManager.CatalogService.Domain.Entities;
 
+/// <summary>
+/// Представляет банковское учреждение
+/// </summary>
+/// <param name="countryId">Идентификатор страны расположения банка</param>
+/// <param name="name">Название банка</param>
 public class Bank(Guid countryId, string name) : IdentityModel
 {
+    /// <summary>
+    /// Идентификатор страны, в которой находится банк
+    /// </summary>
     public Guid CountryId { get; set; } = countryId;
 
+    /// <summary>
+    /// Страна расположения банка
+    /// </summary>
     public Country Country { get; set; } = null!;
     
+    /// <summary>
+    /// Название банка
+    /// </summary>
     public string Name { get; set; } = name;
 }

--- a/src/backend/FinanceManager.CatalogService/FinanceManager.CatalogService.Domain/Entities/Bank.cs
+++ b/src/backend/FinanceManager.CatalogService/FinanceManager.CatalogService.Domain/Entities/Bank.cs
@@ -1,0 +1,12 @@
+﻿using FinanceManager.CatalogService.Domain.Abstractions;
+
+namespace FinanceManager.CatalogService.Domain.Entities;
+
+public class Bank(Guid countryId, string name) : IdentityModel
+{
+    public Guid CountryId { get; set; } = countryId;
+
+    public Country Country { get; set; } = null!;
+    
+    public string Name { get; set; } = name;
+}

--- a/src/backend/FinanceManager.CatalogService/FinanceManager.CatalogService.Domain/Entities/Category.cs
+++ b/src/backend/FinanceManager.CatalogService/FinanceManager.CatalogService.Domain/Entities/Category.cs
@@ -1,0 +1,31 @@
+﻿using FinanceManager.CatalogService.Domain.Abstractions;
+
+namespace FinanceManager.CatalogService.Domain.Entities;
+
+public class Category(
+    Guid registryHolderId,
+    string name,
+    bool income,
+    bool expense,
+    string? emoji,
+    byte[]? icon,
+    Guid? parentId) : IdentityModel
+{
+    public Guid RegistryHolderId { get; set; } = registryHolderId;
+    
+    public RegistryHolder RegistryHolder { get; set; } = null!;
+
+    public string Name { get; set; } = name;
+
+    public bool Income { get; set; } = income;
+
+    public bool Expense { get; set; } = expense;
+
+    public string? Emoji { get; set; } = emoji;
+
+    public byte[]? Icon { get; set; } = icon;
+
+    public Guid? ParentId { get; set; } = parentId;
+    
+    public Category? Parent { get; set; }
+}

--- a/src/backend/FinanceManager.CatalogService/FinanceManager.CatalogService.Domain/Entities/Category.cs
+++ b/src/backend/FinanceManager.CatalogService/FinanceManager.CatalogService.Domain/Entities/Category.cs
@@ -2,6 +2,16 @@
 
 namespace FinanceManager.CatalogService.Domain.Entities;
 
+/// <summary>
+/// Представляет категорию доходов или расходов
+/// </summary>
+/// <param name="registryHolderId">Идентификатор владельца категории</param>
+/// <param name="name">Название категории</param>
+/// <param name="income">Является ли категория доходной</param>
+/// <param name="expense">Является ли категория расходной</param>
+/// <param name="emoji">Эмодзи для категории</param>
+/// <param name="icon">Иконка категории в виде массива байтов</param>
+/// <param name="parentId">Идентификатор родительской категории</param>
 public class Category(
     Guid registryHolderId,
     string name,
@@ -11,21 +21,48 @@ public class Category(
     byte[]? icon,
     Guid? parentId) : IdentityModel
 {
+    /// <summary>
+    /// Идентификатор владельца категории
+    /// </summary>
     public Guid RegistryHolderId { get; set; } = registryHolderId;
     
+    /// <summary>
+    /// Владелец категории
+    /// </summary>
     public RegistryHolder RegistryHolder { get; set; } = null!;
 
+    /// <summary>
+    /// Название категории
+    /// </summary>
     public string Name { get; set; } = name;
 
+    /// <summary>
+    /// Флаг, указывающий, что категория предназначена для доходов
+    /// </summary>
     public bool Income { get; set; } = income;
 
+    /// <summary>
+    /// Флаг, указывающий, что категория предназначена для расходов
+    /// </summary>
     public bool Expense { get; set; } = expense;
 
+    /// <summary>
+    /// Эмодзи для визуального представления категории
+    /// </summary>
     public string? Emoji { get; set; } = emoji;
 
+    /// <summary>
+    /// Иконка категории в виде массива байтов
+    /// </summary>
     public byte[]? Icon { get; set; } = icon;
 
+    /// <summary>
+    /// Идентификатор родительской категории для создания иерархии
+    /// </summary>
     public Guid? ParentId { get; set; } = parentId;
     
+    /// <summary>
+    /// Родительская категория
+    /// </summary>
     public Category? Parent { get; set; }
 }

--- a/src/backend/FinanceManager.CatalogService/FinanceManager.CatalogService.Domain/Entities/Country.cs
+++ b/src/backend/FinanceManager.CatalogService/FinanceManager.CatalogService.Domain/Entities/Country.cs
@@ -1,0 +1,8 @@
+﻿using FinanceManager.CatalogService.Domain.Abstractions;
+
+namespace FinanceManager.CatalogService.Domain.Entities;
+
+public class Country(string name) : IdentityModel
+{
+    public string Name { get; set; } = name;
+}

--- a/src/backend/FinanceManager.CatalogService/FinanceManager.CatalogService.Domain/Entities/Country.cs
+++ b/src/backend/FinanceManager.CatalogService/FinanceManager.CatalogService.Domain/Entities/Country.cs
@@ -2,7 +2,14 @@
 
 namespace FinanceManager.CatalogService.Domain.Entities;
 
+/// <summary>
+/// Представляет справочник стран
+/// </summary>
+/// <param name="name">Название страны</param>
 public class Country(string name) : IdentityModel
 {
+    /// <summary>
+    /// Название страны
+    /// </summary>
     public string Name { get; set; } = name;
 }

--- a/src/backend/FinanceManager.CatalogService/FinanceManager.CatalogService.Domain/Entities/Currency.cs
+++ b/src/backend/FinanceManager.CatalogService/FinanceManager.CatalogService.Domain/Entities/Currency.cs
@@ -1,0 +1,19 @@
+﻿using FinanceManager.CatalogService.Domain.Abstractions;
+
+namespace FinanceManager.CatalogService.Domain.Entities;
+
+public class Currency(string name, string charCode, string numCode, string? sign, string? emoji, bool isDeleted)
+    : IdentityModel
+{
+    public string Name { get; set; } = name;
+
+    public string CharCode { get; set; } = charCode;
+
+    public string NumCode { get; set; } = numCode;
+
+    public string? Sign { get; set; } = sign;
+
+    public string? Emoji { get; set; } = emoji;
+
+    public bool IsDeleted { get; set; } = isDeleted;
+}

--- a/src/backend/FinanceManager.CatalogService/FinanceManager.CatalogService.Domain/Entities/Currency.cs
+++ b/src/backend/FinanceManager.CatalogService/FinanceManager.CatalogService.Domain/Entities/Currency.cs
@@ -2,18 +2,45 @@
 
 namespace FinanceManager.CatalogService.Domain.Entities;
 
+/// <summary>
+/// Представляет справочник валют
+/// </summary>
+/// <param name="name">Название валюты</param>
+/// <param name="charCode">Символьный код валюты</param>
+/// <param name="numCode">Числовой код валюты</param>
+/// <param name="sign">Символ валюты</param>
+/// <param name="emoji">Эмодзи валюты</param>
+/// <param name="isDeleted">Удалена ли валюта</param>
 public class Currency(string name, string charCode, string numCode, string? sign, string? emoji, bool isDeleted)
     : IdentityModel
 {
+    /// <summary>
+    /// Полное название валюты
+    /// </summary>
     public string Name { get; set; } = name;
 
+    /// <summary>
+    /// Символьный код валюты (например, USD, EUR)
+    /// </summary>
     public string CharCode { get; set; } = charCode;
 
+    /// <summary>
+    /// Числовой код валюты согласно ISO 4217
+    /// </summary>
     public string NumCode { get; set; } = numCode;
 
+    /// <summary>
+    /// Символ валюты (например, $, €)
+    /// </summary>
     public string? Sign { get; set; } = sign;
 
+    /// <summary>
+    /// Эмодзи для представления валюты
+    /// </summary>
     public string? Emoji { get; set; } = emoji;
 
+    /// <summary>
+    /// Флаг мягкого удаления валюты
+    /// </summary>
     public bool IsDeleted { get; set; } = isDeleted;
 }

--- a/src/backend/FinanceManager.CatalogService/FinanceManager.CatalogService.Domain/Entities/ExchangeRate.cs
+++ b/src/backend/FinanceManager.CatalogService/FinanceManager.CatalogService.Domain/Entities/ExchangeRate.cs
@@ -1,0 +1,14 @@
+﻿using FinanceManager.CatalogService.Domain.Abstractions;
+
+namespace FinanceManager.CatalogService.Domain.Entities;
+
+public class ExchangeRate(DateTime rateDate, Guid currencyId, decimal rate) : IdentityModel
+{
+    public DateTime RateDate { get; set; } = rateDate;
+
+    public Guid CurrencyId { get; set; } = currencyId;
+
+    public Currency Currency { get; set; } = null!;
+
+    public decimal Rate { get; set; } = rate;
+}

--- a/src/backend/FinanceManager.CatalogService/FinanceManager.CatalogService.Domain/Entities/ExchangeRate.cs
+++ b/src/backend/FinanceManager.CatalogService/FinanceManager.CatalogService.Domain/Entities/ExchangeRate.cs
@@ -2,13 +2,31 @@
 
 namespace FinanceManager.CatalogService.Domain.Entities;
 
+/// <summary>
+/// Представляет справочник обменного курса валют на определенную дату
+/// </summary>
+/// <param name="rateDate">Дата курса</param>
+/// <param name="currencyId">Идентификатор валюты</param>
+/// <param name="rate">Значение курса</param>
 public class ExchangeRate(DateTime rateDate, Guid currencyId, decimal rate) : IdentityModel
 {
+    /// <summary>
+    /// Дата, на которую действует курс валюты
+    /// </summary>
     public DateTime RateDate { get; set; } = rateDate;
 
+    /// <summary>
+    /// Идентификатор валюты
+    /// </summary>
     public Guid CurrencyId { get; set; } = currencyId;
 
+    /// <summary>
+    /// Валюта, для которой установлен курс
+    /// </summary>
     public Currency Currency { get; set; } = null!;
 
+    /// <summary>
+    /// Значение обменного курса
+    /// </summary>
     public decimal Rate { get; set; } = rate;
 }

--- a/src/backend/FinanceManager.CatalogService/FinanceManager.CatalogService.Domain/Entities/RegistryHolder.cs
+++ b/src/backend/FinanceManager.CatalogService/FinanceManager.CatalogService.Domain/Entities/RegistryHolder.cs
@@ -3,9 +3,20 @@ using FinanceManager.CatalogService.Domain.Enums;
 
 namespace FinanceManager.CatalogService.Domain.Entities;
 
+/// <summary>
+/// Представляет владельца реестра финансовых данных
+/// </summary>
+/// <param name="telegramId">Идентификатор пользователя в Telegram</param>
+/// <param name="role">Роль пользователя в системе</param>
 public class RegistryHolder(long telegramId, Role role) : IdentityModel
 {
+    /// <summary>
+    /// Уникальный идентификатор пользователя в Telegram
+    /// </summary>
     public long TelegramId { get; set; } = telegramId;
 
+    /// <summary>
+    /// Роль пользователя в системе финансового менеджера
+    /// </summary>
     public Role Role { get; set; } = role;
 }

--- a/src/backend/FinanceManager.CatalogService/FinanceManager.CatalogService.Domain/Entities/RegistryHolder.cs
+++ b/src/backend/FinanceManager.CatalogService/FinanceManager.CatalogService.Domain/Entities/RegistryHolder.cs
@@ -1,0 +1,11 @@
+﻿using FinanceManager.CatalogService.Domain.Abstractions;
+using FinanceManager.CatalogService.Domain.Enums;
+
+namespace FinanceManager.CatalogService.Domain.Entities;
+
+public class RegistryHolder(long telegramId, Role role) : IdentityModel
+{
+    public long TelegramId { get; set; } = telegramId;
+
+    public Role Role { get; set; } = role;
+}

--- a/src/backend/FinanceManager.CatalogService/FinanceManager.CatalogService.Domain/Enums/Role.cs
+++ b/src/backend/FinanceManager.CatalogService/FinanceManager.CatalogService.Domain/Enums/Role.cs
@@ -1,7 +1,17 @@
 ﻿namespace FinanceManager.CatalogService.Domain.Enums;
 
+/// <summary>
+/// Определяет роли пользователей в системе финансового менеджера
+/// </summary>
 public enum Role
 {
+    /// <summary>
+    /// Обычный пользователь с базовыми правами доступа
+    /// </summary>
     User,
+    
+    /// <summary>
+    /// Администратор системы с расширенными правами управления
+    /// </summary>
     Administrator
 }

--- a/src/backend/FinanceManager.CatalogService/FinanceManager.CatalogService.Domain/Enums/Role.cs
+++ b/src/backend/FinanceManager.CatalogService/FinanceManager.CatalogService.Domain/Enums/Role.cs
@@ -1,0 +1,7 @@
+﻿namespace FinanceManager.CatalogService.Domain.Enums;
+
+public enum Role
+{
+    User,
+    Administrator
+}

--- a/src/backend/FinanceManager.CatalogService/FinanceManager.CatalogService.Domain/FinanceManager.CatalogService.Domain.csproj
+++ b/src/backend/FinanceManager.CatalogService/FinanceManager.CatalogService.Domain/FinanceManager.CatalogService.Domain.csproj
@@ -1,0 +1,9 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net8.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+    </PropertyGroup>
+
+</Project>

--- a/src/backend/FinanceManager.CatalogService/FinanceManager.CatalogService.sln
+++ b/src/backend/FinanceManager.CatalogService/FinanceManager.CatalogService.sln
@@ -2,6 +2,12 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FinanceManager.CatalogService.API", "FinanceManager.CatalogService.API\FinanceManager.CatalogService.API.csproj", "{CC569748-107D-4D50-A2B5-E52ED549EE3F}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "API", "API", "{31862AF6-6CEF-47EB-8D41-03938FD15C4F}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Domain", "Domain", "{F198B861-A801-4805-ACEE-7445B93BBC4C}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FinanceManager.CatalogService.Domain", "FinanceManager.CatalogService.Domain\FinanceManager.CatalogService.Domain.csproj", "{E4EE9A98-B732-4022-891B-5AE92AB3F85C}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -12,5 +18,13 @@ Global
 		{CC569748-107D-4D50-A2B5-E52ED549EE3F}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{CC569748-107D-4D50-A2B5-E52ED549EE3F}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{CC569748-107D-4D50-A2B5-E52ED549EE3F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E4EE9A98-B732-4022-891B-5AE92AB3F85C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E4EE9A98-B732-4022-891B-5AE92AB3F85C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E4EE9A98-B732-4022-891B-5AE92AB3F85C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E4EE9A98-B732-4022-891B-5AE92AB3F85C}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{CC569748-107D-4D50-A2B5-E52ED549EE3F} = {31862AF6-6CEF-47EB-8D41-03938FD15C4F}
+		{E4EE9A98-B732-4022-891B-5AE92AB3F85C} = {F198B861-A801-4805-ACEE-7445B93BBC4C}
 	EndGlobalSection
 EndGlobal


### PR DESCRIPTION
# Add XML Documentation for Domain Layer

## 📋 Summary
Added comprehensive XML documentation for all classes, properties, and enums in the Domain layer of FinanceManager.CatalogService.

## 🔧 Changes Made
- **Domain/Abstractions**: Added XML docs for `IdentityModel` base class
- **Domain/Entities**: Added XML docs for all entity classes:
    - `Account` - Financial account with type, currency, and bank relationships
    - `AccountType` - Account type classification
    - `Bank` - Banking institution entity
    - `Category` - Income/expense categories with hierarchy support
    - `Country` - Country reference data
    - `Currency` - Currency with codes and symbols
    - `ExchangeRate` - Currency exchange rates by date
    - `RegistryHolder` - System users with Telegram integration
- **Domain/Enums**: Added XML docs for `Role` enum (User, Administrator)